### PR TITLE
chore: Tweak CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     paths-ignore: ['**.md']
   pull_request: {}
   workflow_dispatch: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,17 +19,16 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run build
-      - run: bun run test
-      # FIXME: Enable coverage reporting once bun test supports it; https://github.com/oven-sh/bun/issues/2311
-      # - name: Report coverage
-      #   if: ${{ github.repository_owner == 'maxmilton' }}
-      #   run: |
-      #     curl -Lo ./cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-      #     chmod +x ./cc-test-reporter
-      #     ./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.json coverage/lcov.info
-      #     ./cc-test-reporter upload-coverage
-      #   env:
-      #     CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      - run: bun run test --coverage-reporter=lcov --coverage-reporter=text
+      - name: Report coverage
+        if: ${{ github.repository_owner == 'maxmilton' }}
+        run: |
+          curl -Lo ./cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.json coverage/lcov.info
+          ./cc-test-reporter upload-coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
   # e2e:
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 10
@@ -38,7 +40,7 @@ jobs:
   #     - run: bun install --frozen-lockfile
   #     - run: bun playwright install chromium
   #     - run: bun run build
-  #     - run: bun run test:e2e --reporter=dot,html
+  #     - run: bun run test:e2e --reporter=dot,html --forbid-only
   #     - uses: actions/upload-artifact@v4
   #       if: always()
   #       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '28 6 * * 4'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '28 6 * * 4'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add concurrency setting to only allow a single CI run on PRs (and cancel in progress)
- Enable coverage reporting